### PR TITLE
Conditionally rendering Navbar Icons

### DIFF
--- a/src/Modules/Profie/index.js
+++ b/src/Modules/Profie/index.js
@@ -42,29 +42,34 @@ class Profile extends Component {
   };
   fetchData = () => {
     const { username } = this.props.match.params;
-    axios({
-      method: 'get',
-      url: `https://calm-waters-47062.herokuapp.com/users/${username}`,
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('cb-token')}`,
-      },
-    })
-      .then((res) => {
-        if (res.data.success) {
-          this.setState({
-            data: res.data.data,
-            loading: false,
-            username: res.data.data.user.username,
-            bio: res.data.data.user.bio,
-          });
-        }
+    this.setState({
+      errors: null,
+      loading: true,
+    }, () => {
+      axios({
+        method: 'get',
+        url: `https://calm-waters-47062.herokuapp.com/users/${username}`,
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('cb-token')}`,
+        },
       })
-      .catch((err) => {
-        this.setState({
-          errors: err.response.data.errors,
-          loading: false,
+        .then((res) => {
+          if (res.data.success) {
+            this.setState({
+              data: res.data.data,
+              loading: false,
+              username: res.data.data.user.username,
+              bio: res.data.data.user.bio,
+            });
+          }
+        })
+        .catch((err) => {
+          this.setState({
+            errors: err.response.data.errors,
+            loading: false,
+          });
         });
-      });
+    });
   };
   render() {
     const {

--- a/src/Modules/Profie/index.js
+++ b/src/Modules/Profie/index.js
@@ -79,12 +79,12 @@ class Profile extends Component {
     return (
       <React.Fragment>
         <Navbar
-          showBackIcon={othersProfile && !editingUserDetails}
+          showBackIcon={!loading && othersProfile && !editingUserDetails}
           showCrossIcon={editingUserDetails}
           handleCancel={() => alert('Add Handler')}
           showCheckIcon={editingUserDetails}
           handleSubmit={() => alert('Add Handler')}
-          showOptionsIcon={!editingUserDetails}
+          showOptionsIcon={!errors && !editingUserDetails}
           options={[
             {
               title: 'Share Profile',


### PR DESCRIPTION
**Profile Page Loader:**
Whenever data is being fetched, setting `loading: true, errors: null`

**Navbar Hide icon logic:**
1. When Loading:
	- Backicon will be hidden
	- Options icon will be visible
2. When Loaded (No Errors):
	- Backicon will be shown if it's other person's profile
	- Options icon will still be visible, but if it's user's profile more options will be there
3. When Loaded (Errors):
	- Backicon will be visible
	- Options icon will be hidded